### PR TITLE
Added l10n provider optional parameters to the Twig filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,23 @@ Use an array as value:
 Usage
 -----
 
+### PHP
+
 Example in a controler
 
     $l10n = $this->getContainer()->get('l10n_bundle.business.l10n_provider');
     $l10n->getL10n('key', 'idLoc');
 
+### Twig
+
 In a twig template you can use the l10n filter
 
-    {{ 'key'|l10n }}
+```yaml
+{{ 'key'|l10n }}
+```
+
+You can also provide parameters such as the default localization and/or the locale.
+
+```yaml
+{{ 'key'|l10n('es', 'ca') }}
+```

--- a/Tests/Twig/Extension/L10nExtensionTest.php
+++ b/Tests/Twig/Extension/L10nExtensionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace L10nBundle\Tests\Twig\Extension;
+
+use L10nBundle\Twig\Extension\L10nExtension;
+
+class L10nExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var L10nExtension
+     */
+    private $l10nExtension;
+
+    /**
+     * @var L10nProvider|ObjectProphecy
+     */
+    private $l10nProvider;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->l10nProvider = $this->getMock(
+            'L10nBundle\Business\L10nProvider',
+            array(
+                'getL10n'
+            ),
+            array(),
+            '',
+            false
+        );
+        $this->l10nExtension = new L10nExtension($this->l10nProvider);
+    }
+
+    /**
+     * Tests a general case.
+     */
+    public function testGetL10n()
+    {
+        $this
+            ->l10nProvider
+            ->expects($this->once())
+            ->method('getL10n')
+            ->with('myKey', 'es', 'ca_ES')
+            ->will($this->returnValue('Dummy'))
+        ;
+
+        $this->assertEquals(
+            'Dummy',
+            $this->l10nExtension->getL10n('myKey', 'es', 'ca_ES')
+        );
+    }
+
+    /**
+     * Tests minimal case.
+     */
+    public function testMinimalGetL10n()
+    {
+        $this
+            ->l10nProvider
+            ->expects($this->once())
+            ->method('getL10n')
+            ->with('myKey', null, null)
+            ->will($this->returnValue('MinimalDummy'))
+        ;
+
+        $this->assertEquals(
+            'MinimalDummy',
+            $this->l10nExtension->getL10n('myKey')
+        );
+    }
+}

--- a/Twig/Extension/L10nExtension.php
+++ b/Twig/Extension/L10nExtension.php
@@ -42,11 +42,13 @@ class L10nExtension extends \Twig_Extension
 
     /**
      * @param string $key
+     * @param string|null $idLocalization
+     * @param string|null $locale
      *
      * @return string
      */
-    public function getL10n($key)
+    public function getL10n($key, $idLocalization = null, $locale = null)
     {
-        return $this->l10nProvider->getL10n($key);
+        return $this->l10nProvider->getL10n($key, $idLocalization, $locale);
     }
 }

--- a/Utils/Loader/Yaml/YamlL10nLoader.php
+++ b/Utils/Loader/Yaml/YamlL10nLoader.php
@@ -76,7 +76,7 @@ class YamlL10nLoader extends FileLoader
      *
      * @return array The file content
      */
-    private function loadFile($file)
+    public function loadFile($file)
     {
         if (!$this->supports($file)) {
             throw new FileLoaderLoadException($file);


### PR DESCRIPTION
Currently, the ```|l10n``` Twig filter doesn't accept any argument. However, the l10nProvider takes 2 more arguments : the "idLocalization" and "locale".

I just added the possibility to use them. It's useful when you need to lookup l10n values based on a custom localization.

This fix will be available on the 1.6.x and 1.7.x branches.

Notice : Tests are old-fashioned - Ignore Travis, it's screwed up